### PR TITLE
esmi_oob_library: Add pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,3 +193,14 @@ if (DOXYGEN_FOUND)
 else()
   message("Doxygen is not found. Will not generate documents.")
 endif(DOXYGEN_FOUND)
+
+# create pkgconfig.
+set(pkgconfig ${PROJECT_SOURCE_DIR}/${APML_LIB_TARGET}.pc)
+set(APML_PKGCONFIG_DIR /usr/local/lib/pkgconfig)
+
+configure_file(
+    "${pkgconfig}.in"
+    "${pkgconfig}"
+    @ONLY)
+
+install(FILES "${pkgconfig}" DESTINATION ${APML_PKGCONFIG_DIR})

--- a/apml64.pc.in
+++ b/apml64.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}lib
+includedir=${prefix}include
+
+Name: @APML_LIB_TARGET@
+Description: AMD APML library
+Version: @BUILD_VERSION_STRING@
+Libs: -L${libdir} -l@APML_LIB_TARGET@
+Cflags: -I${includedir}


### PR DESCRIPTION
This repo uses current directory as the install path to put header files and libraries.
However only the header files/libraries placed in `/usr/local` will be searched by default.
So we need to add pkgconfig to specify the path of the header/lib for apml.

Tested: Tested locally.

Signed-off-by: Michael Shen <gpgpgp@google.com>